### PR TITLE
v0.0.17

### DIFF
--- a/content.js
+++ b/content.js
@@ -113,7 +113,7 @@ function showNotification(type, extensionStatusJSON) {
 
   logo.setAttribute(
     "src",
-    "https://github.com/yakshaG/google-meet-slack-integration/raw/main/icon.png"
+    "https://yakshag.github.io/gmeet-slack-integration-status/icon.png"
   );
   logo.setAttribute("height", "32px");
   logo.setAttribute("width", "32px");
@@ -172,7 +172,7 @@ async function checkExtensionStatus() {
 
   // https://stackoverflow.com/a/42518434
   await fetch(
-    "https://raw.githubusercontent.com/yakshaG/gmeet-slack-integration-status/main/status-prod.json",
+    "https://yakshag.github.io/gmeet-slack-integration-status/status-prod.json",
     { cache: "no-store" }
   )
     .then((response) => response.json())

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Meet ⇔ Slack integration",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "manifest_version": 3,
   "description": "Real-time Google Meet status on Slack, just like Slack huddles.",
   "action": {


### PR DESCRIPTION
Since some ISPs seem to block the IP of `raw.githubusercontent.com`, the remote URLs now point to Github pages instances of the same JSON and PNG files.